### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/skygenesisenterprise/company-website/security/code-scanning/15](https://github.com/skygenesisenterprise/company-website/security/code-scanning/15)

To fix this problem, add an explicit `permissions` block at the workflow root to set the minimal required GitHub token privileges. Since this is a simple CI workflow that checks out and tests code, it does not require any write permissions, so we can safely set `contents: read`. This is achieved by inserting a `permissions:` block before the `jobs:` key in `.github/workflows/test.yml` (after `on:` block). No further changes are needed since this covers all jobs unless overridden by a job-specific permissions block.

**What to change:**  
- In `.github/workflows/test.yml`, just after the `on:` block (line 11), add:

  ```yaml
  permissions:
    contents: read
  ```

No imports, methods, or variable definitions are needed for this YAML fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
